### PR TITLE
Password inputs don't support default-value("Placeholder Text")

### DIFF
--- a/demos/fauxform.html
+++ b/demos/fauxform.html
@@ -106,6 +106,12 @@
         </div>
         
         <div class="ctrlHolder">
+          <label for=""><em>*</em> Password text input</label>
+          <input name="" id="" data-default-value="Placeholder text" size="35" maxlength="50" type="password" class="textInput large"/>
+          <p class="formHint">This is a form hint.</p>
+        </div>
+        
+        <div class="ctrlHolder">
           <label for=""><em>*</em> Large text input</label>
           <input name="" id="" data-default-value="Placeholder text" size="35" maxlength="50" type="text" class="textInput large"/>
           <p class="formHint">This is a form hint.</p>

--- a/js/uni-form.jquery.js
+++ b/js/uni-form.jquery.js
@@ -61,11 +61,15 @@ jQuery.fn.uniform = function(settings) {
                 value = $input.val();
 
             $input.data('default-color',$input.css('color'));
+            $input.data('true-type', $input[0].type);
 
             if (value == $input.data('default-value') || ! value) {
                 $input.not('select').css("color",settings.default_value_color);
                 $input.val($input.data('default-value'));
 
+		if($input[0].type == 'password') {
+		    $input[0].type = 'text';
+		}
             }
         })
 
@@ -78,6 +82,10 @@ jQuery.fn.uniform = function(settings) {
             
             if($input.val() == $input.data('default-value')){
                 $input.val("");
+                
+                if($input.data('true-type') == 'password') {
+                    $input[0].type = $input.data('true-type');
+                }
             }
 
             $input.not('select').css('color',$input.data('default-color'));
@@ -89,6 +97,10 @@ jQuery.fn.uniform = function(settings) {
             if($input.val() == "" || $input.val() == $input.data('default-value')){
                 $input.not('select').css("color",settings.default_value_color);
                 $input.val($input.data('default-value'));
+                
+                if($input.data('true-type') == 'password') {
+		    $input[0].type = 'text';
+		}
             } else {
                 $input.css('color',$input.data('default-color'));
             }


### PR DESCRIPTION
I added some functionality(very minimal) to support placeholder text in password inputs. I didn't update the minified js version thou. I'm not sure what process your using to create the mn.js.

Thanks & awesome library!

-Sean
