### PR TITLE
jQ-Validation: New method to retrieve label-strings, show errors in errorMsg

### DIFF
--- a/js/uni-form-validation.jquery.js
+++ b/js/uni-form-validation.jquery.js
@@ -23,7 +23,7 @@
  */
 
 jQuery.fn.uniform = function(extended_settings) {
-    var messages = {} // errors of all fields by their names
+    var errors = {} // errors of all fields by their names
     /**
      * Self reference for closures
      *
@@ -405,37 +405,34 @@ jQuery.fn.uniform = function(extended_settings) {
     };
 
     /** 
-     * Uni-Form form validation error
-     *
-     * @param string title of the form error
-     * @param array  list of error messages to show
-     *
-     * @return false
-     */
+    * Uni-Form form validation error
+    *
+    * @param string title of the form error
+    * @param array  list of error messages to show
+    *
+    * @return false
+    */
     var showFormError = function(form, title, messages) {
-      if($('#errorMsg').length) {
-        $('#errorMsg').remove();
-      }
-      $message =
-          $('<div />')
-              .attr('id','errorMsg')
-              .html("<h3>" + title + "</h3>");
-      if(messages.length) {
-          $message.append($('<ol />'));
-          for(m in messages) {
-              $('ol', $message).append(
-                  $('<li />').text(messages[m])
-              );
-          }
-      }
-      form.prepend($message);
-      $('html, body').animate({
-          scrollTop: form.offset().top
-      }, 500);
-      $('#errorMsg').slideDown();
-      return false;
+        if($('#errorMsg').length) {
+            $('#errorMsg').remove();
+        }
+        $message = $('<div />')
+            .attr('id','errorMsg')
+            .attr('style','display:none')
+            .html("<h3>" + title + "</h3>");
+        $message.append($('<ol />'));
+        for(m in messages) {
+            $('ol', $message).append(
+                $('<li />').text(messages[m]
+            ));
+        }
+        form.prepend($message);
+        $scrollableArea = $('div.mainbody');
+        $scrollableArea.animate({scrollTop: '0px'}, 200);
+        $('#errorMsg').slideDown(800);
+        return false;
     };
-    
+
     var showFormSuccess = function(form, title) {
       if($('#okMsg').length) {
         $('#okMsg').remove();
@@ -465,23 +462,14 @@ jQuery.fn.uniform = function(extended_settings) {
          * @return null
          */
         var validate = function($input,valid,text) {
-            var $p = $input.closest('div.' + settings.holder_class)
+            $input.closest('div.' + settings.holder_class)
                            .andSelf()
                            .toggleClass(settings.invalid_class, !valid)
                            .toggleClass(settings.error_class, !valid)
                            .toggleClass(settings.valid_class, valid)
-                           .find('p.formHint');
-    
-            if (! valid && ! $p.data('info-text')) {
-                $p.data('info-text', $p.html());
-            }
-            else if (valid) {
-                text = $p.data('info-text');
-            }
-    
-            if (text) {
-                $p.html(text);
-            }
+                           //.find('p.formHint'); // do nothing with it
+            if (! valid)
+                errors[$input.attr("name")] = text;
         };
         
         /**

--- a/js/uni-form-validation.jquery.js
+++ b/js/uni-form-validation.jquery.js
@@ -21,8 +21,9 @@
  * @see http://sprawsm.com/uni-form/
  * @license MIT http://www.opensource.org/licenses/mit-license.php
  */
+
 jQuery.fn.uniform = function(extended_settings) {
-    
+    var messages = {} // errors of all fields by their names
     /**
      * Self reference for closures
      *
@@ -193,7 +194,8 @@ jQuery.fn.uniform = function(extended_settings) {
                 var target_field = jQuery('input[name="' + target_field_name + '"]');
                 if(target_field.length > 0) {
                     if(target_field.val() != field.val()) {
-                        var target_field_caption = target_field.closest('div.'+settings.holder_class).find('label').text().replace('*','');
+                        //var target_field_caption = target_field.closest('div.'+settings.holder_class).find('label').text().replace('*','');
+                        var target_field_caption = get_label_text(target_field);
                         return i18n('same_as', caption, target_field_caption);
                     }
                 }
@@ -363,6 +365,18 @@ jQuery.fn.uniform = function(extended_settings) {
         }
   
     };
+
+    /**
+     * get the text of the label that belongs to the field
+     * @param field jQ object, e.g. $("#email")
+     */
+    get_label_text = function(field) {
+        var text = field.closest('label').text();
+        if (text == "") {
+            text = field.closest('div.' + settings.holder_class).find('label').text();
+        }
+        return text.replace('*','').replace(':','');
+    }
 
     /** 
      * Simple replacement for i18n + sprintf
@@ -597,9 +611,9 @@ jQuery.fn.uniform = function(extended_settings) {
          */
         form.delegate(settings.field_selector, 'blur', function() {
             var $input = $(this);
-            var label  = $(this)
-                .closest('div.' + settings.holder_class)
-                .find('label').text().replace('*','');
+            var label  = get_label_text($(this));
+                //.closest('div.' + settings.holder_class)
+                //.find('label').text().replace('*','');
 
             // remove focus from form element
             form.find('.' + settings.focused_class).removeClass(settings.focused_class);

--- a/js/uni-form-validation.jquery.js
+++ b/js/uni-form-validation.jquery.js
@@ -23,7 +23,7 @@
  */
 
 jQuery.fn.uniform = function(extended_settings) {
-    var errors = {} // errors of all fields by their names
+    var errors = {}; // errors of all fields by their names
     /**
      * Self reference for closures
      *
@@ -427,8 +427,7 @@ jQuery.fn.uniform = function(extended_settings) {
             ));
         }
         form.prepend($message);
-        $scrollableArea = $('div.mainbody');
-        $scrollableArea.animate({scrollTop: '0px'}, 200);
+        settings.scrollable_area.animate({scrollTop: '0px'}, 200);
         $('#errorMsg').slideDown(400);
         return false;
     };
@@ -713,5 +712,6 @@ jQuery.fn.uniform.defaults = {
     focused_class           : 'focused',
     holder_class            : 'ctrlHolder',
     field_selector          : 'input, textarea, select',
-    default_value_color     : "#AFAFAF"
+    default_value_color     : "#AFAFAF",
+    scrollable_area         : $('html, body')
 };

--- a/js/uni-form-validation.jquery.js
+++ b/js/uni-form-validation.jquery.js
@@ -429,7 +429,7 @@ jQuery.fn.uniform = function(extended_settings) {
         form.prepend($message);
         $scrollableArea = $('div.mainbody');
         $scrollableArea.animate({scrollTop: '0px'}, 200);
-        $('#errorMsg').slideDown(800);
+        $('#errorMsg').slideDown(400);
         return false;
     };
 
@@ -449,28 +449,32 @@ jQuery.fn.uniform = function(extended_settings) {
       return false;
     };
 
+    /**
+     * Set the results of form validation on the form element
+     * NOTE: shall be overridable
+     *
+     * @param object $input jQuery form element
+     * @param bool   valid  true if the form value passed all validation
+     * @param string text   validation error message to display
+     *
+     * @return null
+     */
+    var validate = function($input,valid,text) {
+        $input.closest('div.' + settings.holder_class)
+             .andSelf()
+             .toggleClass(settings.invalid_class, !valid)
+             .toggleClass(settings.error_class, !valid)
+             .toggleClass(settings.valid_class, valid)
+             //.find('p.formHint'); // do nothing with it
+        name = $input.attr("name");
+        if (! valid)
+            errors[name] = text;
+        else if (name in errors)
+            delete errors[name];
+    };
+
     return this.each(function() {
         var form = jQuery(this);
-        
-        /**
-         * Set the results of form validation on the form element
-         *
-         * @param object $input jQuery form element
-         * @param bool   valid  true if the form value passed all validation
-         * @param string text   validation error message to display
-         *
-         * @return null
-         */
-        var validate = function($input,valid,text) {
-            $input.closest('div.' + settings.holder_class)
-                           .andSelf()
-                           .toggleClass(settings.invalid_class, !valid)
-                           .toggleClass(settings.error_class, !valid)
-                           .toggleClass(settings.valid_class, valid)
-                           //.find('p.formHint'); // do nothing with it
-            if (! valid)
-                errors[$input.attr("name")] = text;
-        };
         
         /**
          * Select form fields and attach the higlighter functionality
@@ -550,7 +554,7 @@ jQuery.fn.uniform = function(extended_settings) {
                 form.addClass('failedSubmit');
                 return ($.isFunction(settings.prevent_submit_callback))
                     ? settings.prevent_submit_callback(form)
-                    : showFormError(form, i18n('submit_msg'), [i18n('submit_help')]);
+                    : showFormError(form, i18n('submit_msg'), errors);
               }
               
               settings.ask_on_leave = false;

--- a/js/uni-form-validation.jquery.js
+++ b/js/uni-form-validation.jquery.js
@@ -552,7 +552,7 @@ jQuery.fn.uniform = function(extended_settings) {
               ) {
                 form.addClass('failedSubmit');
                 return ($.isFunction(settings.prevent_submit_callback))
-                    ? settings.prevent_submit_callback(form)
+                    ? settings.prevent_submit_callback(form, i18n('submit_msg'), errors)
                     : showFormError(form, i18n('submit_msg'), errors);
               }
               


### PR DESCRIPTION
- I added a method get_label_text(), as the way it was handled before did not work with MultiFileds: It turned all labels in the div into one string (e.g. "Multifield with text inputs").
- You may not want some changes I did to the validate() method. The things I thought were neccessary were to move it to be a method of jQuery.fn.uniform, so it is easier to override it and let it fill an errors{}-object, that CAN be used by showFormError().
- I changed the way prevent_submit_callback() is called: it takes the same set of parameters as showFormError(), now.
- I added scrollable_area to the settings: For some layouts, the form will be part of a certain area, that is scrolled instead of the hole website.

As I said, you may not want some changes, as I removed some functionality from validate()*. But I hope some changes you like ;)

*The reason for me is, that I want to have the same behaviour no matter if JS is on/off. And I use some HTML5-features that cause modern browsers to do inline-validation already.
